### PR TITLE
Add branching to update command

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -41,6 +41,7 @@
 - [`bs test:report`](#bs-testreport)
 - [`bs test:run`](#bs-testrun)
 - [`bs test:unpack`](#bs-testunpack)
+- [`bs update`](#bs-update)
 - [`bs wiki`](#bs-wiki)
 - [`bs help [COMMAND]`](#bs-help-command)
 - [`bs plugins`](#bs-plugins)
@@ -865,6 +866,27 @@ ALIASES
 ```
 
 _See code: [src/commands/test/unpack.ts](https://github.com/daymxn/bs-cli/blob/main/src/commands/test/unpack.ts)_
+
+## [`bs update`](#bs-update)
+
+Update your CLI to the latest version.
+
+```text
+USAGE
+  $ bs update [--branch <value>]
+
+FLAGS
+  --branch=<value>  [default: main] Github branch to pull the update from
+
+DESCRIPTION
+  Since bs isn't published to any registry, you can use this command to automatically update your github repo
+  dependency.
+
+  If this command isn't working for some reason, you can manually run `pnpm add daymxn/bs-cli`, and pnpm will pull the
+  latest version.
+```
+
+_See code: [src/commands/update.ts](https://github.com/daymxn/bs-cli/blob/main/src/commands/update.ts)_
 
 ## [`bs wiki`](#bs-wiki)
 

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "prereprod": "pnpm build",
     "format": "eslint . --fix",
     "manifest": "oclif manifest",
-    "prepare": "pnpm build && pnpm manifest",
+    "postinstall": "pnpm build && pnpm manifest",
     "readme": "pnpm reprod readme",
     "update": "pnpm readme && pnpm manifest",
     "preupdate": "shx rm -f oclif.manifest.json"

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -16,19 +16,35 @@
  */
 
 import { pnpm } from "#src/util/apps.js";
+import { inlineCode } from "#src/util/markup.js";
+import { Flags } from "@oclif/core";
 
 import { BaseCommand } from "./base-command.js";
 
 export default class UpdateCommand extends BaseCommand<typeof UpdateCommand> {
-  public static description =
-    "Since bs isn't published to any registry, you can use this command to automatically update your github repo dependency.";
+  public static description = `
+Since bs isn't published to any registry, you can use this command to automatically update your github repo dependency.
+
+If this command isn't working for some reason, you can manually run ${inlineCode("pnpm add daymxn/bs-cli")}, and pnpm will pull the latest version.
+`.trim();
+
+  static override flags = {
+    branch: Flags.string({
+      default: "main",
+      description: "Github branch to pull the update from",
+    }),
+  };
 
   public static summary = "Update your CLI to the latest version.";
 
   public async run() {
     this.i("Updating CLI");
 
-    await pnpm("pnpm add daymxn/bs-cli");
+    const { branch } = this.flags;
+
+    this.d("Pulling from branch: %s", branch);
+
+    await pnpm(`pnpm add daymxn/bs-cli#${branch}`);
 
     this.d("CLI updated");
 


### PR DESCRIPTION
This adds a branch param to the update command and also migrates `prepare` to `postinstall` as that should run on `rebuild`.